### PR TITLE
[WIP]Main view

### DIFF
--- a/app/assets/javascripts/projects.coffee
+++ b/app/assets/javascripts/projects.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/projects.coffee
+++ b/app/assets/javascripts/projects.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -1,0 +1,126 @@
+/*!
+ * YUI 3.5.0 - reset.css (http://developer.yahoo.com/yui/3/cssreset/)
+ * http://cssreset.com
+ * Copyright 2012 Yahoo! Inc. All rights reserved.
+ * http://yuilibrary.com/license/
+ */
+/*
+    TODO will need to remove settings on HTML since we can't namespace it.
+    TODO with the prefix, should I group by selector or property for weight savings?
+*/
+html{
+    color:#000;
+    background:#FFF;
+}
+/*
+    TODO remove settings on BODY since we can't namespace it.
+*/
+/*
+    TODO test putting a class on HEAD.
+        - Fails on FF.
+*/
+body,
+div,
+dl,
+dt,
+dd,
+ul,
+ol,
+li,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+pre,
+code,
+form,
+fieldset,
+legend,
+input,
+textarea,
+p,
+blockquote,
+th,
+td {
+    margin:0;
+    padding:0;
+}
+table {
+    border-collapse:collapse;
+    border-spacing:0;
+}
+fieldset,
+img {
+    border:0;
+}
+/*
+    TODO think about hanlding inheritence differently, maybe letting IE6 fail a bit...
+*/
+address,
+caption,
+cite,
+code,
+dfn,
+em,
+strong,
+th,
+var {
+    font-style:normal;
+    font-weight:normal;
+}
+
+ol,
+ul {
+    list-style:none;
+}
+
+caption,
+th {
+    text-align:left;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-size:100%;
+    font-weight:normal;
+}
+q:before,
+q:after {
+    content:'';
+}
+abbr,
+acronym {
+    border:0;
+    font-variant:normal;
+}
+/* to preserve line-height and selector appearance */
+sup {
+    vertical-align:text-top;
+}
+sub {
+    vertical-align:text-bottom;
+}
+input,
+textarea,
+select {
+    font-family:inherit;
+    font-size:inherit;
+    font-weight:inherit;
+}
+/*to enable resizing for IE*/
+input,
+textarea,
+select {
+    *font-size:100%;
+}
+/*because legend doesn't inherit in IE */
+legend {
+    color:#000;
+}
+/* YUI CSS Detection Stamp */
+#yui3-css-stamp.cssreset { display: none; }

--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the projects controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,0 +1,2 @@
+class ProjectsController < ApplicationController
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,2 +1,5 @@
 class ProjectsController < ApplicationController
+
+  def index
+  end
 end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -1,0 +1,2 @@
+module ProjectsHelper
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,2 @@
+class Project < ApplicationRecord
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,2 +1,4 @@
 class Project < ApplicationRecord
+  belongs_go :company
+  has_many :messages
 end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,0 +1,42 @@
+<div class="main-view">
+  <header>
+    <div id="logo">
+    </div>
+    <div class="header__nav">
+    </div>
+    <input>
+    <div class="header__icon">
+    </div>
+    <div class="header__profile-image">
+    </div>
+  </header>
+  <div class="contents">
+    <div class="carousel">
+    </div>
+    <div class="sub-content">
+      <div class="sub-content__search">
+      </div>
+      <div class="sub-content__field">
+      </div>
+      <div class="sub-content__region">
+      </div>
+      <div class="sub-content__character">
+      </div>
+    </div>
+    <div class="main-content">
+      <div class="main-content__nav">
+      </div>
+      <div class="main-content__item">
+      </div>
+    </div>
+  </div>
+  <footer>
+    <div class="company-info">
+    </div>
+    <input>
+    <div class="footer__logo">
+    </div>
+    <div class="footer__icon">
+    </div>
+  </footer>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ module Wantedly22b
       g.helper          false
       g.javascripts     false
       g.test_framework  false
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,11 @@ Bundler.require(*Rails.groups)
 
 module Wantedly22b
   class Application < Rails::Application
+    config.generators do |g|
+      g.assets          false
+      g.helper          false
+      g.javascripts     false
+      g.test_framework  false
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  root 'projects#index'
+  resources :projects, only: [:index]
 end

--- a/db/migrate/20180313035049_create_projects.rb
+++ b/db/migrate/20180313035049_create_projects.rb
@@ -1,0 +1,8 @@
+class CreateProjects < ActiveRecord::Migration[5.0]
+  def change
+    create_table :projects do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180313035049_create_projects.rb
+++ b/db/migrate/20180313035049_create_projects.rb
@@ -1,7 +1,11 @@
 class CreateProjects < ActiveRecord::Migration[5.0]
   def change
     create_table :projects do |t|
-
+      t.text :title, null: false, index: true
+      t.text :content, null: false
+      t.string :job_title, null: false
+      t.integer :job_type, null: false, index: true
+      t.references :company, foreign_key: true,
       t.timestamps
     end
   end

--- a/db/migrate/20180313035049_create_projects.rb
+++ b/db/migrate/20180313035049_create_projects.rb
@@ -1,11 +1,11 @@
 class CreateProjects < ActiveRecord::Migration[5.0]
   def change
     create_table :projects do |t|
-      t.text :title, null: false, index: true
+      t.string :title, null: false, index: true
       t.text :content, null: false
       t.string :job_title, null: false
       t.integer :job_type, null: false, index: true
-      t.references :company, foreign_key: true,
+      # t.references :company, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20180313035049) do
+
+  create_table "projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "title",                    null: false
+    t.text     "content",    limit: 65535, null: false
+    t.string   "job_title",                null: false
+    t.integer  "job_type",                 null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.index ["job_type"], name: "index_projects_on_job_type", using: :btree
+    t.index ["title"], name: "index_projects_on_title", using: :btree
+  end
+
+end

--- a/log/development.log
+++ b/log/development.log
@@ -56,3 +56,49 @@ puma (3.11.3) lib/puma/thread_pool.rb:120:in `block in spawn_thread'
   Rendering /Users/konotatsuya/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
   Rendered /Users/konotatsuya/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (0.6ms)
   Rendered /Users/konotatsuya/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb within rescues/layout (146.5ms)
+  [1m[35m (34.7ms)[0m  [1m[35mCREATE TABLE `schema_migrations` (`version` varchar(255) PRIMARY KEY) ENGINE=InnoDB[0m
+  [1m[35m (11.2ms)[0m  [1m[35mCREATE TABLE `ar_internal_metadata` (`key` varchar(255) PRIMARY KEY, `value` varchar(255), `created_at` datetime NOT NULL, `updated_at` datetime NOT NULL) ENGINE=InnoDB[0m
+  [1m[35m (0.7ms)[0m  [1m[34mSELECT DATABASE() as db[0m
+  [1m[35m (0.8ms)[0m  [1m[34mSELECT GET_LOCK('5459610886180542105', 0);[0m
+  [1m[36mActiveRecord::SchemaMigration Load (2.4ms)[0m  [1m[34mSELECT `schema_migrations`.* FROM `schema_migrations`[0m
+Migrating to CreateProjects (20180313035049)
+  [1m[35m (0.8ms)[0m  [1m[34mSELECT RELEASE_LOCK('5459610886180542105')[0m
+  [1m[35m (0.1ms)[0m  [1m[34mSELECT DATABASE() as db[0m
+  [1m[35m (0.1ms)[0m  [1m[34mSELECT GET_LOCK('5459610886180542105', 0);[0m
+  [1m[36mActiveRecord::SchemaMigration Load (0.3ms)[0m  [1m[34mSELECT `schema_migrations`.* FROM `schema_migrations`[0m
+Migrating to CreateProjects (20180313035049)
+  [1m[35m (0.5ms)[0m  [1m[35mCREATE TABLE `projects` (`id` int AUTO_INCREMENT PRIMARY KEY, `title` text NOT NULL, `content` text NOT NULL, `job_title` varchar(255) NOT NULL, `job_type` int NOT NULL, `company_id` int, `created_at` datetime NOT NULL, `updated_at` datetime NOT NULL,  INDEX `index_projects_on_title`  (`title`),  INDEX `index_projects_on_job_type`  (`job_type`),  INDEX `index_projects_on_company_id`  (`company_id`), CONSTRAINT `fk_rails_44a549d7b3`
+FOREIGN KEY (`company_id`)
+  REFERENCES `companies` (`id`)
+) ENGINE=InnoDB[0m
+  [1m[35m (0.1ms)[0m  [1m[34mSELECT RELEASE_LOCK('5459610886180542105')[0m
+  [1m[35m (0.1ms)[0m  [1m[34mSELECT DATABASE() as db[0m
+  [1m[35m (0.2ms)[0m  [1m[34mSELECT GET_LOCK('5459610886180542105', 0);[0m
+  [1m[36mActiveRecord::SchemaMigration Load (0.2ms)[0m  [1m[34mSELECT `schema_migrations`.* FROM `schema_migrations`[0m
+Migrating to CreateProjects (20180313035049)
+  [1m[35m (0.2ms)[0m  [1m[34mSELECT RELEASE_LOCK('5459610886180542105')[0m
+  [1m[35m (0.1ms)[0m  [1m[34mSELECT DATABASE() as db[0m
+  [1m[35m (0.1ms)[0m  [1m[34mSELECT GET_LOCK('5459610886180542105', 0);[0m
+  [1m[36mActiveRecord::SchemaMigration Load (0.3ms)[0m  [1m[34mSELECT `schema_migrations`.* FROM `schema_migrations`[0m
+Migrating to CreateProjects (20180313035049)
+  [1m[35m (18.5ms)[0m  [1m[35mCREATE TABLE `projects` (`id` int AUTO_INCREMENT PRIMARY KEY, `title` varchar(255) NOT NULL, `content` text NOT NULL, `job_title` varchar(255) NOT NULL, `job_type` int NOT NULL, `company_id` int, `created_at` datetime NOT NULL, `updated_at` datetime NOT NULL,  INDEX `index_projects_on_title`  (`title`),  INDEX `index_projects_on_job_type`  (`job_type`),  INDEX `index_projects_on_company_id`  (`company_id`), CONSTRAINT `fk_rails_44a549d7b3`
+FOREIGN KEY (`company_id`)
+  REFERENCES `companies` (`id`)
+) ENGINE=InnoDB[0m
+  [1m[35m (0.2ms)[0m  [1m[34mSELECT RELEASE_LOCK('5459610886180542105')[0m
+  [1m[35m (0.1ms)[0m  [1m[34mSELECT DATABASE() as db[0m
+  [1m[35m (0.1ms)[0m  [1m[34mSELECT GET_LOCK('5459610886180542105', 0);[0m
+  [1m[36mActiveRecord::SchemaMigration Load (0.2ms)[0m  [1m[34mSELECT `schema_migrations`.* FROM `schema_migrations`[0m
+Migrating to CreateProjects (20180313035049)
+  [1m[35m (18.9ms)[0m  [1m[35mCREATE TABLE `projects` (`id` int AUTO_INCREMENT PRIMARY KEY, `title` varchar(255) NOT NULL, `content` text NOT NULL, `job_title` varchar(255) NOT NULL, `job_type` int NOT NULL, `created_at` datetime NOT NULL, `updated_at` datetime NOT NULL,  INDEX `index_projects_on_title`  (`title`),  INDEX `index_projects_on_job_type`  (`job_type`)) ENGINE=InnoDB[0m
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[35mSQL (4.0ms)[0m  [1m[32mINSERT INTO `schema_migrations` (`version`) VALUES ('20180313035049')[0m
+  [1m[35m (1.1ms)[0m  [1m[35mCOMMIT[0m
+  [1m[36mActiveRecord::InternalMetadata Load (2.3ms)[0m  [1m[34mSELECT  `ar_internal_metadata`.* FROM `ar_internal_metadata` WHERE `ar_internal_metadata`.`key` = 'environment' LIMIT 1[0m
+  [1m[35m (0.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[35mSQL (0.8ms)[0m  [1m[32mINSERT INTO `ar_internal_metadata` (`key`, `value`, `created_at`, `updated_at`) VALUES ('environment', 'development', '2018-03-13 04:17:37', '2018-03-13 04:17:37')[0m
+  [1m[35m (0.4ms)[0m  [1m[35mCOMMIT[0m
+  [1m[35m (0.1ms)[0m  [1m[34mSELECT RELEASE_LOCK('5459610886180542105')[0m
+  [1m[36mActiveRecord::SchemaMigration Load (0.4ms)[0m  [1m[34mSELECT `schema_migrations`.* FROM `schema_migrations`[0m
+  [1m[35m (1.2ms)[0m  [1m[35mSHOW CREATE TABLE `projects`[0m
+  [1m[35m (0.9ms)[0m  [1m[35mSHOW TABLE STATUS LIKE 'projects'[0m

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ProjectsController, type: :controller do
+
+end

--- a/spec/helpers/projects_helper_spec.rb
+++ b/spec/helpers/projects_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ProjectsHelper. For example:
+#
+# describe ProjectsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ProjectsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Project, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
#what
求人一覧表示機能実装
（概要）
wantedlyの「募集をみる」のページと最初に表示されるページが同じなのではじめにprojectsのindexを作成。
（https://www.wantedly.com/projects と https://www.wantedly.com　が同じ画面）
（詳細）
・projectモデル、projectsコントローラー作成
・モデルにアソシエーション追記
・DB作成,　projectsテーブル作成
・ルーティングに必要事項追記
・コントローラーにindexアクション追記
・view→pfojectsディレクトリ内にindexファイル作成（大枠は作成）
・reset.scss作成

※view画面は大枠の箱（divタグなど）しか作成していませんが、
reset.scssなど他のメンバーも使用する機能などがあるので一旦これでプルリクしました。
この後は、全ページ共通のヘッダーとフッターを作成してプルリクし、その後、求人一覧表メイン画面に着手する予定です。

#why
必須機能のため

